### PR TITLE
- rework refill thresholds for multi-stack shelving in 1.4

### DIFF
--- a/Source/VarietyMattersStockpile/Harmony/Patch_Building_Storage.cs
+++ b/Source/VarietyMattersStockpile/Harmony/Patch_Building_Storage.cs
@@ -11,7 +11,7 @@ public class Patch_Building_Storage
     public static void Postfix_ReceivedThing(Building_Storage __instance)
     {
         //Log.Message("Stockpile received something");
-        StorageLimits.CheckIfFull(__instance.GetSlotGroup());
+        StorageLimits.CheckIfFull(__instance.GetSlotGroup(), __instance);
     }
 
     [HarmonyPatch("Notify_LostThing")]
@@ -20,7 +20,7 @@ public class Patch_Building_Storage
     {
         //Log.Message("Something removed from stockpile");
         var slotGroup = __instance.GetSlotGroup();
-        StorageLimits.CheckNeedsFilled(slotGroup,
+        StorageLimits.CheckNeedsFilled(slotGroup, __instance,
             ref StorageLimits.GetLimitSettings(slotGroup.Settings).needsFilled,
             ref StorageLimits.GetLimitSettings(slotGroup.Settings).cellsFilled);
     }

--- a/Source/VarietyMattersStockpile/Harmony/Patch_Zone_Stockpile.cs
+++ b/Source/VarietyMattersStockpile/Harmony/Patch_Zone_Stockpile.cs
@@ -11,7 +11,7 @@ public class Patch_Zone_Stockpile
     public static void Postfix_ReceivedThing(Zone_Stockpile __instance)
     {
         //Log.Message("Stockpile received something");
-        StorageLimits.CheckIfFull(__instance.GetSlotGroup());
+        StorageLimits.CheckIfFull(__instance.GetSlotGroup(), null);
     }
 
     [HarmonyPatch("RemoveCell")]
@@ -19,7 +19,7 @@ public class Patch_Zone_Stockpile
     public static void Postfix_RemoveCell(Zone_Stockpile __instance)
     {
         //Log.Message("Stockpile is smaller, check if it still needs to be filled");
-        StorageLimits.CheckIfFull(__instance.GetSlotGroup());
+        StorageLimits.CheckIfFull(__instance.GetSlotGroup(), null);
     }
 
     [HarmonyPatch("Notify_LostThing")]
@@ -28,7 +28,7 @@ public class Patch_Zone_Stockpile
     {
         //Log.Message("Something removed from stockpile");
         var slotGroup = __instance.GetSlotGroup();
-        StorageLimits.CheckNeedsFilled(slotGroup,
+        StorageLimits.CheckNeedsFilled(slotGroup, null,
             ref StorageLimits.GetLimitSettings(slotGroup.Settings).needsFilled,
             ref StorageLimits.GetLimitSettings(slotGroup.Settings).cellsFilled);
     }


### PR DESCRIPTION
Hey,

A patch to rework the refill thresholds to account for maxItemsPerCell with the new 1.4 storage.  From my testing things look to work, pawns will now fully refill shelves and the behaviour for zones looks unchanged.

Any questions let me know