### PR TITLE
- rework refill thresholds for multi-stack shelving in 1.4

### DIFF
--- a/Source/VarietyMattersStockpile/Harmony/Patch_Building_Storage.cs
+++ b/Source/VarietyMattersStockpile/Harmony/Patch_Building_Storage.cs
@@ -11,7 +11,7 @@ public class Patch_Building_Storage
     public static void Postfix_ReceivedThing(Building_Storage __instance)
     {
         //Log.Message("Stockpile received something");
-        StorageLimits.CheckIfFull(__instance.GetSlotGroup());
+        StorageLimits.CheckIfFull(__instance.GetSlotGroup(), __instance.MaxItemsInCell);
     }
 
     [HarmonyPatch("Notify_LostThing")]
@@ -20,7 +20,7 @@ public class Patch_Building_Storage
     {
         //Log.Message("Something removed from stockpile");
         var slotGroup = __instance.GetSlotGroup();
-        StorageLimits.CheckNeedsFilled(slotGroup,
+        StorageLimits.CheckNeedsFilled(slotGroup, __instance.MaxItemsInCell,
             ref StorageLimits.GetLimitSettings(slotGroup.Settings).needsFilled,
             ref StorageLimits.GetLimitSettings(slotGroup.Settings).cellsFilled);
     }

--- a/Source/VarietyMattersStockpile/Harmony/Patch_StoreUtility.cs
+++ b/Source/VarietyMattersStockpile/Harmony/Patch_StoreUtility.cs
@@ -23,7 +23,7 @@ public class Patch_StoreUtility
 
         //Log.Message("Get Limit Settings");
         var limitSettings = StorageLimits.GetLimitSettings(slotGroup.Settings);
-        if (slotGroup.CellsList.Count != 1 && !limitSettings.needsFilled && limitSettings.cellFillPercentage < 1)
+        if (!limitSettings.needsFilled && limitSettings.cellFillPercentage < 1)
         {
             return false;
         }

--- a/Source/VarietyMattersStockpile/Harmony/Patch_Zone_Stockpile.cs
+++ b/Source/VarietyMattersStockpile/Harmony/Patch_Zone_Stockpile.cs
@@ -11,7 +11,7 @@ public class Patch_Zone_Stockpile
     public static void Postfix_ReceivedThing(Zone_Stockpile __instance)
     {
         //Log.Message("Stockpile received something");
-        StorageLimits.CheckIfFull(__instance.GetSlotGroup());
+        StorageLimits.CheckIfFull(__instance.GetSlotGroup(), 1);
     }
 
     [HarmonyPatch("RemoveCell")]
@@ -19,7 +19,7 @@ public class Patch_Zone_Stockpile
     public static void Postfix_RemoveCell(Zone_Stockpile __instance)
     {
         //Log.Message("Stockpile is smaller, check if it still needs to be filled");
-        StorageLimits.CheckIfFull(__instance.GetSlotGroup());
+        StorageLimits.CheckIfFull(__instance.GetSlotGroup(), 1);
     }
 
     [HarmonyPatch("Notify_LostThing")]
@@ -28,7 +28,7 @@ public class Patch_Zone_Stockpile
     {
         //Log.Message("Something removed from stockpile");
         var slotGroup = __instance.GetSlotGroup();
-        StorageLimits.CheckNeedsFilled(slotGroup,
+        StorageLimits.CheckNeedsFilled(slotGroup, 1,
             ref StorageLimits.GetLimitSettings(slotGroup.Settings).needsFilled,
             ref StorageLimits.GetLimitSettings(slotGroup.Settings).cellsFilled);
     }


### PR DESCRIPTION
Hey,

A v2 patch version to fix the refill thresholds to accomodate the multi-stack shelving in v1.4.  Its survived a few hours of playtesting here and looks to be working fine for both single-cell and multi-cell storage

There's an edge case where it will still stop filling if it gets a partial stack into an empty slot, but fixing that created the opposite problem where it'd never stop filling if it had a partial stack that couldn't be merged into, which seems to happen a lot with meals so I left it be

Hopefully it looks ok, if there's anything that needs changing I'll happily take a look

Cheers,